### PR TITLE
feat: 홈화면에서 그룹지도 누르면 그룹지도 상세 페이지로 가도록 라우팅 구현

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,6 +25,7 @@ import StartRecommendGroupReqeust from "./page/RecommendFlow/Group/StartRecommen
 import StartMakePlace from "./page/Splash/StartMakePlaceSplash.jsx";
 import RecommendSplash from "./page/Splash/RecommendSplash.jsx";
 import StationPage from "./page/HomePage/StationPage.jsx";
+import GroupPlaceMapPage from "./page/PlaceMapPage/GroupPlaceMapPage.jsx";
 
 const router = createBrowserRouter([
   {
@@ -34,6 +35,7 @@ const router = createBrowserRouter([
       { index: true, element: <HomePage /> },
       { path: "place-map/:slug", element: <PlaceMapPage /> },
       { path: "station/:slug", element: <StationPage /> },
+      { path: "group-place-map/:slug", element: <GroupPlaceMapPage /> }, // /station 으로 바로 접근시 홈으로
 
       {
         path: "start-make-place",

--- a/src/page/HomePage/HomePage.jsx
+++ b/src/page/HomePage/HomePage.jsx
@@ -66,6 +66,7 @@ export default function HomePage() {
   const MOCK_GROUPS = [
     {
       id: "g1",
+      slug: "group-1",
       name: "일이삼사",
       thumbnail: "", // 이미지 없으면 이니셜 fallback
       stationName: "홍대입구역",
@@ -73,6 +74,7 @@ export default function HomePage() {
     },
     {
       id: "g2",
+      slug: "group-2",
       name: "친구들 모임",
       thumbnail: "",
       stationName: "강남역",
@@ -80,6 +82,7 @@ export default function HomePage() {
     },
     {
       id: "g3",
+      slug: "group-3",
       name: "동아리",
       thumbnail: "",
       stationName: "홍대입구역",
@@ -87,6 +90,7 @@ export default function HomePage() {
     },
     {
       id: "g1",
+      slug: "group-4",
       name: "그룹명",
       thumbnail: "", // 이미지 없으면 이니셜 fallback
       stationName: "숭실대입구역",
@@ -94,6 +98,7 @@ export default function HomePage() {
     },
     {
       id: "g2",
+      slug: "group-5",
       name: "친구들 모임",
       thumbnail: "",
       stationName: "강남역",
@@ -174,7 +179,7 @@ export default function HomePage() {
       <GroupList
         title="그룹 지도"
         groups={MOCK_GROUPS}
-        onItemClick={(g) => navigate(`/group/${g.id}`)}
+        onItemClick={(g) => navigate(`/group-place-map/${g.slug}`)}
       />
       <ButtonContainer>
         <Button onClick={handleAddMapClick}>나만의 지도 추가하기</Button>

--- a/src/page/PlaceMapPage/GroupPlaceMapPage.jsx
+++ b/src/page/PlaceMapPage/GroupPlaceMapPage.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+
+export default function GroupPlaceMapPage() {
+  const slug = useParams().slug;
+  return (
+    <div>
+      GroupPlaceMapPage
+      {slug}
+    </div>
+  );
+}


### PR DESCRIPTION
# Pull Request (PR)

PR 유형을 선택해주세요.
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🧾변경 사항
- 그룹지도 목업 데이터에 slug가 없어서 추가
- main.jsx에 GroupPlaceMapPage로 가는 라우팅 추가
- 테스트 할 수 있도록 GroupPlaceMapPage에 slug 글씨 출력하도록 함


## 👀 특별히 봐줬으면 하는 부분
- 리뷰어가 중점적으로 봐야 할 코드 섹션 또는 로직을 지정하세요.

## ℹ️ 기타
- main.jsx 건들였으니까 머지할 때 주의할 것!!
