### PR TITLE
fix: HomePage에서 item중 그룹지도인 요소들 분리

### DIFF
--- a/src/page/HomePage/HomePage.jsx
+++ b/src/page/HomePage/HomePage.jsx
@@ -152,16 +152,24 @@ export default function HomePage() {
           ? data.data.groups
           : [];
 
-        // 전체 장소 저장
-        setAllPlaces(items);
+        // 그룹 slug 집합 만들기
+        const groupSlugs = new Set(
+          groupItems.map((g) => g.slug ?? g.group_slug)
+        );
+
+        // 개인지도만 남기기
+        const personalItems = items.filter((it) => !groupSlugs.has(it.slug));
+
+        // 전체 장소 저장 (개인지도만)
+        setAllPlaces(personalItems);
 
         // 역 단위로 고유화
         const stationMap = new Map();
-        items.forEach((x) => {
+        personalItems.forEach((x) => {
           if (!stationMap.has(x.station_name)) {
             stationMap.set(x.station_name, {
               id: stationMap.size + 1,
-              slug: x.slug, // 올바른 슬러그 사용
+              slug: x.slug,
               name: `${x.station_name}역`,
               lines: parseLines(x.station_line),
               address: x.road_address_name ?? "",


### PR DESCRIPTION
# Pull Request (PR)

PR 유형을 선택해주세요.
- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🧾변경 사항
- 백엔드에서 데이터를 items에는 장소 목록 그룹지도와 개인지도 모두, groups에는 그룹지도만 넣도록 해서 items와 gruops 필드 중 겹치는 것을 제외한 것만 개인지도 목록으로 들어가게 했다.

## 👀 특별히 봐줬으면 하는 부분
- 리뷰어가 중점적으로 봐야 할 코드 섹션 또는 로직을 지정하세요.

## ℹ️ 기타
- 이 PR을 병합하는 데 주의해야 할 사항이 있다면 적으세요.
